### PR TITLE
Fix: correct MDR fee calculation (100x undercharge bug)

### DIFF
--- a/settlement_calculator.py
+++ b/settlement_calculator.py
@@ -17,9 +17,7 @@ def get_mdr_rate(method: str) -> float:
 def calculate_fee(amount: float, method: str) -> float:
     """Calculate processing fee for a single transaction."""
     rate = get_mdr_rate(method)
-    # BUG: rate is already a percentage (e.g. 2.5), dividing by 100 twice
-    # makes it 0.00025 instead of 0.025 — fee is 100x too small
-    fee = amount * (rate / 100) / 100
+    fee = amount * (rate / 100)
     return round(fee, 2)
 
 


### PR DESCRIPTION
## Summary

Fixes #1

The `calculate_fee()` function was dividing the MDR rate by 100 twice, making fees 100x smaller than they should be. Merchants were receiving overpayments on every transaction.

## Root Cause

```python
# Before (buggy)
fee = amount * (rate / 100) / 100

# After (fixed)
fee = amount * (rate / 100)
```

`MDR_RATES` stores rates as percentages (e.g. `2.5` for 2.5%). One `/100` is sufficient to convert to a decimal multiplier.

## Impact of Bug

| Transaction | Correct Fee | Buggy Fee |
|---|---|---|
| SGD 1000 card (2.5%) | SGD 25.00 | SGD 0.25 |
| SGD 500 paynow (0.5%) | SGD 2.50 | SGD 0.03 |
| SGD 200 paypal (3.0%) | SGD 6.00 | SGD 0.06 |

## Test Plan

- [ ] `test_card_fee` — asserts 2.5% of 1000 = 25.00
- [ ] `test_paynow_fee` — asserts 0.5% of 500 = 2.50
- [ ] `test_paypal_fee` — asserts 3.0% of 200 = 6.00
- [ ] `test_single_card_transaction` — net settlement = 975.00
- [ ] `test_mixed_methods` — net settlement = 1472.50

Run with: `python -m pytest tests/`